### PR TITLE
fix: use plain when no rich.html file

### DIFF
--- a/app/models/letter_opener_web/letter.rb
+++ b/app/models/letter_opener_web/letter.rb
@@ -61,6 +61,10 @@ module LetterOpenerWeb
       style_exists?('rich') ? 'rich' : 'plain'
     end
 
+    def default_text
+      @default_test ||= adjust_link_targets(read_file(default_style))
+    end
+
     def attachments
       @attachments ||= Dir["#{base_dir}/attachments/*"].each_with_object({}) do |file, hash|
         hash[File.basename(file)] = File.expand_path(file)
@@ -76,7 +80,7 @@ module LetterOpenerWeb
     end
 
     def subject
-      @subject ||= rich_text.scan(%r{<dt>Subject:</dt>[^<]*<dd><strong>([^>]+)</strong>}).last.first
+      @subject ||= default_text.scan(%r{<dt>Subject:</dt>[^<]*<dd><strong>([^>]+)</strong>}).last.first
     end
 
     private
@@ -90,7 +94,7 @@ module LetterOpenerWeb
     end
 
     def style_exists?(style)
-      File.exist?("#{base_dir}/#{style}.html")
+      File.file?("#{base_dir}/#{style}.html")
     end
 
     def adjust_link_targets(contents)

--- a/spec/models/letter_opener_web/letter_spec.rb
+++ b/spec/models/letter_opener_web/letter_spec.rb
@@ -74,7 +74,7 @@ MAIL
     end
 
     it 'returns plain if rich text version is not present' do
-      allow(File).to receive_messages(exist?: false)
+      allow(File).to receive_messages(file?: false)
       expect(subject.default_style).to eq('plain')
     end
   end


### PR DESCRIPTION
Есть у нас письма без html, просто текстом, из за них падает просмотр.